### PR TITLE
Changes buggy ubuntugis packages to ubuntugis-unstable

### DIFF
--- a/.github/workflows/django-ci.yml
+++ b/.github/workflows/django-ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - devel
       - main
-  
+
   push:
     branches:
       - devel
@@ -19,14 +19,14 @@ jobs:
     services:
       postgres:
         image: postgis/postgis:14-master
-        env:  # environmental variables required for the job
+        env: # environmental variables required for the job
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: github_actions
-        ports: 
+        ports:
           - 5432:5432
 
-        options: >- 
+        options: >-
           --health-cmd pg_isready 
           --health-interval 10s 
           --health-timeout 5s 
@@ -40,15 +40,15 @@ jobs:
           path: ~/.cache/zip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-           ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-
       - name: Setup python environment
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install GDAL library
         run: |
-          sudo add-apt-repository ppa:ubuntugis/ppa -y
-          sudo apt-get update -y
+          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+          sudo apt-get update
           sudo apt-get install gdal-bin libgdal-dev -y
           export CPLUS_INCLUDE_PATH=/usr/include/gdal
           export C_INCLUDE_PATH=/usr/include/gdal
@@ -63,6 +63,5 @@ jobs:
         run: |
           nohup python citizenvoice/manage.py runserver &
           sleep 5
-      - name: Stop Development Server 
+      - name: Stop Development Server
         run: pkill -f runserver
-        


### PR DESCRIPTION
It seemed like the ubuntugis/ppa package is corrupted. It putted out the following error:
`The repository 'https://ppa.launchpadcontent.net/ubuntugis/ppa/ubuntu jammy Release' does not have a Release file.`
Changing the package to `ubuntugis-unstable` seems to resolve the issue.