### PR TITLE
Second attempt at merge for actions/routes in views.py and survey store

### DIFF
--- a/frontend/pages/design/index.vue
+++ b/frontend/pages/design/index.vue
@@ -2,7 +2,7 @@
     <NuxtLayout name="default">
         <div class="flex flex-row">
             <h2 class="inline-block">Surveys</h2>
-            <v-btn variant="outlined" @click="addNewSurvey" href="/design/surveys/create">Add
+            <v-btn variant="outlined" href="/design/surveys/create">Add
                 survey</v-btn>
         </div>
 
@@ -43,9 +43,8 @@ definePageMeta({
     alias: '/design/surveys'
 })
 
-const url = "/api/surveys/"
 const surveyStore = useSurveyStore()
-const { data: surveys, refresh } = await useAsyncData(() => $cmsApi(url));
+
 var expire_date = new Date();
 var current_date = new Date();
 const textName = ref(null)
@@ -54,6 +53,16 @@ const textDescription = ref(null)
 // set default expire date 100 days after current day
 expire_date.setDate(expire_date.getDate() + 100);
 current_date.setDate(current_date.getDate());
+
+let response = ref({})
+let refresh = ref(() => {})
+let surveys = ref ({})
+
+onMounted(async () => {
+  const response_ = await surveyStore.getSurveysOfCurrentUser()
+  response.value = response_
+  surveys.value = response_.data.value
+});
 
 // Add a new survey using the surveyStore, based on what is entered in the field.
 const addNewSurvey = async () => {

--- a/frontend/pages/survey/[_id]/[_question].vue
+++ b/frontend/pages/survey/[_id]/[_question].vue
@@ -2,6 +2,22 @@
     <NuxtLayout name="default">
         <div class="">
             <!-- Question card: number & text -->
+
+            <v-card v-for="question in questions" class="my-card">
+              <div class="text-h2 q-mt-sm q-mb-xs">Question {{ question.order }}</div>
+              <div class="text-h5 q-mt-sm q-mb-xs">{{question.text}}</div>
+            </v-card>
+        </div>
+
+        <div class="">
+            <!-- Map card
+          real v-if statement = (question.map_view != null || question.is_geospatial)-->
+<!--            <v-card v-if="question.is_geospatial" style="min-width: 300px;" class="my-card col">-->
+<!--                <div class="text-h5 q-mt-sm q-mb-xs">Map here</div>-->
+<!--                <div id="map"></div>-->
+<!--            </v-card>-->
+        </div>
+
             <div class="my-card">
                 <div class="text-h2 q-mt-sm q-mb-xs">Question {{ $route.params._question }}</div>
                 <div class="text-h5 q-mt-sm q-mb-xs">{{ question.text }}</div>
@@ -44,12 +60,12 @@
         <div class="q-pa-md row">
             <v-btn @click="prevQuestion" color="primary">
                 <i class="fa-solid fa-arrow-left"></i>
-                <span class="q-pa-sm">Previous</span>
+              <span class="q-pa-sm">Previous Question</span>
             </v-btn>
             <v-space />
             <v-btn @click="nextQuestion" color="primary">
                 <i class="fa-solid fa-arrow-right"></i>
-                <span class="q-pa-sm">Next</span>
+              <span class="q-pa-sm">Next Question</span>
             </v-btn>
         </div>
 
@@ -71,8 +87,15 @@ const question_url = "/api/questions/"
 const mapview_url = "/api/map_views/"
 
 const route = useRoute()
+// Fixme: Cleanup these functions
+import {useSurveyStore} from "~/stores/survey.js";
+const survey_store = useSurveyStore()
+// const { data: survey } = await useAsyncData(() => $cmsApi(survey_url + route.params._id));
+const { data : questions } = await survey_store.getQuestionsOfSurvey(route.params._id)
+var current_question_index = 0
 
 const survey = await responseStore.getResponse(route.params._id)
+
 
 // TODO: use an API to get n'th question of the selected survey
 let demo_question = 3 // This is a hardcoded value for now
@@ -92,19 +115,13 @@ const circles = ref([]) // this is what user will add
 let circleClickedAndRemoved = false
 let resetClicked = false
 
+
 // to navigate from one question to the previous/next
 const prevQuestion = async () => {
-    // if this is not the first question:
-    let question_to_navigate = (parseInt(route.params._question, 10) - 1)
-    if (question_to_navigate != 0) {
-        return navigateTo('/survey/' + route.params._id + '/' + question_to_navigate)
-    } else {
-        return navigateTo('/survey/' + route.params._id)
-    }
+// TODO: Implement
 }
 const nextQuestion = async () => {
-    // if this is not the last question:
-    return navigateTo('/survey/' + route.params._id + '/' + (parseInt(route.params._question, 10) + 1))
+// TODO: Implement
 }
 
 // inspired by Roy J's solution on Stack Overflow:
@@ -132,6 +149,7 @@ const resetMap = async () => {
     // TODO: reset map center and zoom level based on map_view
     resetClicked = true
 }
+
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
# Description of changes

## !important
- Check whether the map is visible when starting a survey in the surveys tab after clicking both start survey buttons

#110 

## What?

- Add view action "my_surveys" to retrieve surveys of logged in user
- Add view action "create_survey" to resolve the issue with creating a survey where the designer is always set to the default of 1
- Add view action "get_questions_of_survey" to get all questions of a published survey
- Add methods in the survey store to request the new actions
- Add code to display the retrieved questions in [_question].vue

## Why?
To resolve a known issue with creating new surveys.
To allow a respondent to view the questions of a survey
To allow a survey designer to view only their own surveys when designing

## Dependencies
No new dependencies required

## Known Issues
For the backend to recognize a user the token and csrf_token need to be send with the request.
After refreshing the website this does not happen for some reason
The code relevant to this issue are the stores in user.js and survey.js
